### PR TITLE
Fixes CMakeLists.txt to first use header files included in this project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,11 +79,11 @@ link_directories(
 )
 
 include_directories(
+	${CMAKE_SOURCE_DIR}/include
 	${ALLEGRO_INCLUDE_DIRS}
 	${GLIB_INCLUDE_DIRS}
 	${LIBXML_INCLUDE_DIRS}
 	${ZLIB_INCLUDE_DIRS}
-	${CMAKE_SOURCE_DIR}/include
 )
 
 file(GLOB allegro_tiled_headers include/allegro5/*.h)


### PR DESCRIPTION
The allegro_tilled.h that's installed on the system gets included first before the one in the local project, which causes build errors after the project allegro_tilled.h has been changed. This fixes it by searching the header files included in the project first.